### PR TITLE
Feat: Added dark theme toggle  #15

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -24,14 +24,6 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
         integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
 
-    <!-- GSAP -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"
-        integrity="sha384-lI86CGWNchoT9leGBpVR41iGrRTRbHRDsPI4Zo/atPOIodjl8YyDaVefcpgkCg4u"
-        crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"
-        integrity="sha384-KzCH6F95MIQm9XSZaq2CeYG0mdJ76k+Ym/k406miaZTdbNDeRR1ZpttJr/GvHicI"
-        crossorigin="anonymous"></script>
-
     <!-- BoxIcons -->
     <link href='https://unpkg.com/boxicons@2.1.1/css/boxicons.min.css' rel='stylesheet'>
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,8 +3,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta property="og:title" content="Personal Portfolio">
-    <meta property="og:description"
-        content="My Personal Portfolio">
+    <meta property="og:description" content="My Personal Portfolio">
     <meta property="og:image" content="./assets/img/social-link.jpg">
     <meta property="og:url" content="{{ page.url }}">
 
@@ -17,14 +16,22 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.2.1/js/bootstrap.min.js"
         integrity="sha384-B0UglyR+jN6CkvvICOB2joaf5I4l3gm9GU6Hc1og6Ls7i6U/mkkaduKaBhlAXv9k"
         crossorigin="anonymous"></script>
-    <script src="https://jsxss.com/assets/xss.js"
-        crossorigin="anonymous"></script>
+    <script src="https://jsxss.com/assets/xss.js" crossorigin="anonymous"></script>
 
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
         integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css"
         integrity="sha256-mmgLkCYLUQbXn0B1SRqzHar6dCnv9oZFPEC1g1cwlkk=" crossorigin="anonymous" />
+
+    <!-- GSAP -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"
+        integrity="sha384-lI86CGWNchoT9leGBpVR41iGrRTRbHRDsPI4Zo/atPOIodjl8YyDaVefcpgkCg4u"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/ScrollTrigger.min.js"
+        integrity="sha384-KzCH6F95MIQm9XSZaq2CeYG0mdJ76k+Ym/k406miaZTdbNDeRR1ZpttJr/GvHicI"
+        crossorigin="anonymous"></script>
+
 
     <link lang='sass' rel="stylesheet" href="/assets/css/main.css">
     <link rel='icon' href='/assets/img/favicon.ico' type='image/x-icon' />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,6 +32,10 @@
         integrity="sha384-KzCH6F95MIQm9XSZaq2CeYG0mdJ76k+Ym/k406miaZTdbNDeRR1ZpttJr/GvHicI"
         crossorigin="anonymous"></script>
 
+    <!-- BoxIcons -->
+    <link href='https://unpkg.com/boxicons@2.1.1/css/boxicons.min.css' rel='stylesheet'>
+
+
 
     <link lang='sass' rel="stylesheet" href="/assets/css/main.css">
     <link rel='icon' href='/assets/img/favicon.ico' type='image/x-icon' />

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -6,10 +6,6 @@
       </div>
     </a>
     <div class="buttons">
-      <div class="control switch switch-lg ml-4">
-        <input type="checkbox" class="control-input" id="dark-theme-toggle" />
-        <label class="control-label mr-2" for="dark-theme-toggle">on</label>
-      </div>
     </div>
   </div>
 </header>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,10 +1,15 @@
 <header class="nav-bar">
-    <div class="nav-content">
-        <a href="{{ '/' | relative_url }}">
-            <div class="nav-logo">
-                <img src="./assets/img/mlh-prep.png" />
-            </div>
-        </a>
-        
+  <div class="nav-content">
+    <a href="{{ '/' | relative_url }}">
+      <div class="nav-logo">
+        <img src="./assets/img/mlh-prep.png" />
+      </div>
+    </a>
+    <div class="buttons">
+      <div class="control switch switch-lg ml-4">
+        <input type="checkbox" class="control-input" id="dark-theme-toggle" />
+        <label class="control-label mr-2" for="dark-theme-toggle">on</label>
+      </div>
     </div>
+  </div>
 </header>

--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,7 +1,7 @@
 <div class="control switch switch-lg ml-4">
     <div id="dark-theme-toggle" class="adaptive-theme-color adaptive-shadow adaptive-text-reverse p-3">
         <!-- OnClick: Registered in assets/js/toggle.js -->
-        <div class="v-center mx-1">
+        <div class="v-center mx-1" id="dark-mode-status-icon-wrapper">
             <i class='bx' id="dark-mode-status-icon"></i>
         </div>
         <div class="v-center mx-1 mobile-hidden" id="dark-mode-status-indicator">

--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,1 +1,32 @@
-<script src="/assets/js/toggle.js"></script>
+<div class="control switch switch-lg ml-4">
+    <div id="dark-theme-toggle" class="adaptive-theme-color adaptive-shadow adaptive-text-reverse p-3">
+        <!-- OnClick: Registered in assets/js/toggle.js -->
+        <div class="v-center mx-1" id="dark-mode-status-icon">
+            [Icon]
+        </div>
+        <div class="v-center mx-1 mobile-hidden" id="dark-mode-status-indicator">
+            [Status]
+        </div>
+    </div>
+    <script src="/assets/js/toggle.js"></script>
+</div>
+
+<style>
+    .y-center {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+
+
+    #dark-theme-toggle {
+        position: fixed;
+        bottom: 3rem;
+        right: 3rem;
+        border-radius: 1rem;
+        display: flex;
+        flex-direction: row;
+        user-select: none;
+        cursor: pointer;
+    }
+</style>

--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,0 +1,1 @@
+<script src="/assets/js/toggle.js"></script>

--- a/_includes/toggle.html
+++ b/_includes/toggle.html
@@ -1,8 +1,8 @@
 <div class="control switch switch-lg ml-4">
     <div id="dark-theme-toggle" class="adaptive-theme-color adaptive-shadow adaptive-text-reverse p-3">
         <!-- OnClick: Registered in assets/js/toggle.js -->
-        <div class="v-center mx-1" id="dark-mode-status-icon">
-            [Icon]
+        <div class="v-center mx-1">
+            <i class='bx' id="dark-mode-status-icon"></i>
         </div>
         <div class="v-center mx-1 mobile-hidden" id="dark-mode-status-indicator">
             [Status]
@@ -18,7 +18,6 @@
         justify-content: center;
     }
 
-
     #dark-theme-toggle {
         position: fixed;
         bottom: 3rem;
@@ -28,5 +27,6 @@
         flex-direction: row;
         user-select: none;
         cursor: pointer;
+        font-weight: bold;
     }
 </style>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -3,16 +3,12 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  {% include header.html %}
+{% include header.html %}
 
-  <body>
-    {{ content }} {% include toggle.html %}
+<body class="hidden">
 
-    <script>
-      const theme = localStorage.getItem("mode");
-      if (theme !== null) {
-        document.body.setAttribute("theme", "dark");
-      }
-    </script>
-  </body>
+  {{ content }}
+
+</body>
+
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,11 +1,18 @@
 ---
 ---
+
 <!DOCTYPE html>
 <html lang="en">
-{% include header.html %}
+  {% include header.html %}
 
-<body>
-    {{ content }}
-</body>
+  <body>
+    {{ content }} {% include toggle.html %}
 
+    <script>
+      const theme = localStorage.getItem("mode");
+      if (theme !== null) {
+        document.body.setAttribute("theme", "dark");
+      }
+    </script>
+  </body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -2,11 +2,12 @@
 layout: default
 ---
 
+
 <div class="banner">
     <div class="container">
         <div class="logo">
             <a href="/">
-                <img src="/assets/img/logo.svg"/>
+                <img src="/assets/img/logo.svg" />
             </a>
         </div>
         <div class="title">
@@ -17,4 +18,6 @@ layout: default
 
 <div class="container page">
     {{ content }}
+    {% include toggle.html %}
+    <!-- Global Wrapper, excluding index.html -->
 </div>

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -3,7 +3,7 @@
 @import "navbar";
 @import "profile";
 @import "page";
-@import "toggle";
+@import "darkmode";
 
 .card-container {
   display: grid;
@@ -30,38 +30,6 @@
   .mobile-hidden {
     display: none;
   }
-}
-
-.adaptive-text {
-  color: #121212;
-}
-
-.adaptive-text-reverse {
-  color: #f5f5f9;
-}
-
-.adaptive-background {
-  background-color: #f5f5f9;
-}
-
-.adaptive-background-reverse {
-  background-color: #121212;
-}
-
-.adaptive-theme-color {
-  background-color: #2c74d8;
-}
-
-.adaptive-shadow {
-  filter: drop-shadow(0 0 1rem rgba(0, 0, 0, 0.2));
-}
-
-.adaptive-background-transparent {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.transition-effect {
-  transition: all 0.3s ease-in-out;
 }
 
 .hidden {

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -1,13 +1,14 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap');
-@import 'navbar';
-@import 'profile';
-@import 'page';
+@import url("https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&display=swap");
+@import "navbar";
+@import "profile";
+@import "page";
+@import "toggle";
 
 .card-container {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    font-family: "Open Sans", sans-serif;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  font-family: "Open Sans", sans-serif;
 }
 
 @media only screen and (max-width: 1500px) {
@@ -28,63 +29,63 @@
   }
 }
 
-
 body {
-    background-color: #f5f5f9;
-    margin-bottom: 50px;
+  background-color: #f5f5f9;
+  margin-bottom: 50px;
 }
 h2 {
-    margin-bottom: 20px;
-    margin-top: 20px;
-    font-weight: 700;
-    text-align: center;
+  margin-bottom: 20px;
+  margin-top: 20px;
+  font-weight: 700;
+  text-align: center;
 }
 
 .card {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    margin: 20px 30px;
-    background-color: white;
-    border-radius: .375rem;
-    padding: 1.5em;
-    font-size: 1.2em;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 20px 30px;
+  background-color: white;
+  border-radius: 0.375rem;
+  padding: 1.5em;
+  font-size: 1.2em;
 }
 
 a {
-    color: black;
+  color: black;
 }
 
 .info {
-    p {
-        margin-top: 5px;
-        margin: 0px;
-        text-align: left;
-    }
+  p {
+    margin-top: 5px;
+    margin: 0px;
+    text-align: left;
+  }
 
-    .title {
-        font-size: 500;
-        font-weight: bold;
-    }
+  .title {
+    font-size: 500;
+    font-weight: bold;
+  }
 
-    .location, .description {
-        font-size: medium;
-        font-weight: 400;
-    }
+  .location,
+  .description {
+    font-size: medium;
+    font-weight: 400;
+  }
 
-    .dates {
-        font-size: small;
-        color: #404040;
-    }
+  .dates {
+    font-size: small;
+    color: #404040;
+  }
 }
 
 .icon {
-    width: 70px;
-    height: 70px;
-    margin-right: 20px;
-    padding: 10px;
+  width: 70px;
+  height: 70px;
+  margin-right: 20px;
+  padding: 10px;
 
-    img {
-        width: 100%;
-    }
+  img {
+    width: 100%;
+  }
 }

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -49,7 +49,7 @@
 }
 
 .adaptive-theme-color {
-  background-color: #2C74D8;
+  background-color: #2c74d8;
 }
 
 .adaptive-shadow {
@@ -58,6 +58,10 @@
 
 .adaptive-background-transparent {
   background-color: rgba(0, 0, 0, 0.1);
+}
+
+.transition-effect {
+  transition: all 0.3s ease-in-out;
 }
 
 .hidden {

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -27,6 +27,41 @@
   .card-container {
     grid-template-columns: 1fr;
   }
+  .mobile-hidden {
+    display: none;
+  }
+}
+
+.adaptive-text {
+  color: #121212;
+}
+
+.adaptive-text-reverse {
+  color: #f5f5f9;
+}
+
+.adaptive-background {
+  background-color: #f5f5f9;
+}
+
+.adaptive-background-reverse {
+  background-color: #121212;
+}
+
+.adaptive-theme-color {
+  background-color: #2C74D8;
+}
+
+.adaptive-shadow {
+  filter: drop-shadow(0 0 1rem rgba(0, 0, 0, 0.2));
+}
+
+.adaptive-background-transparent {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.hidden {
+  opacity: 0;
 }
 
 body {

--- a/_sass/darkmode.scss
+++ b/_sass/darkmode.scss
@@ -35,7 +35,9 @@
   p {
     color: #9396a5 !important;
   }
+}
 
+[theme="dark"] {
   .adaptive-background {
     background-color: #1e1e29;
   }
@@ -60,4 +62,36 @@
   .adaptive-theme-color {
     background-color: #b9d1f2;
   }
+}
+
+.adaptive-text {
+  color: #121212;
+}
+
+.adaptive-text-reverse {
+  color: #f5f5f9;
+}
+
+.adaptive-background {
+  background-color: #f5f5f9;
+}
+
+.adaptive-background-reverse {
+  background-color: #121212;
+}
+
+.adaptive-theme-color {
+  background-color: #2c74d8;
+}
+
+.adaptive-shadow {
+  filter: drop-shadow(0 0 1rem rgba(0, 0, 0, 0.2));
+}
+
+.adaptive-background-transparent {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.transition-effect {
+  transition: all 0.3s ease-in-out;
 }

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -1,36 +1,73 @@
 .nav-bar {
-    width: 100%;
-    background-color: #133667;
-    font-family: "Poppins", serif;
-    font-weight: 700 !important;
-    padding-top: 10px;
+  width: 100%;
+  background-color: #133667;
+  font-family: "Poppins", serif;
+  font-weight: 700 !important;
+  padding-top: 10px;
 }
 
 .nav-content .logo-touch-target {
-    display: inline-flex;
-    height: 60%;
-    width: 350px;
+  display: inline-flex;
+  height: 60%;
+  width: 350px;
 }
 
 .nav-content .nav-logo {
-    height: 60px;
-    margin: auto;
+  height: 60px;
+  margin: auto;
 }
 
 .nav-logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .nav-logo img {
-    width: 200px;
+  width: 200px;
 }
 
 .nav-content nav {
-    display: block;
-    width: 100%;
-    text-align: right;
-    padding-top: 0px;
-    padding-right: 0px;
+  display: block;
+  width: 100%;
+  text-align: right;
+  padding-top: 0px;
+  padding-right: 0px;
+}
+
+// toggle btn
+.buttons {
+  display: flex;
+  align-items: center;
+}
+
+.control-label {
+  color: #ffffff;
+  font-family: "Open Sans", sans-serif;
+}
+
+.switch.switch-lg {
+  padding-bottom: 0.5rem;
+  padding-left: 2.25rem;
+
+  & .control-label {
+    padding-left: 0.75rem;
+    padding-top: 0.15rem;
+
+    &::before {
+      border-radius: 1rem;
+      height: 1.5rem;
+      width: 2.5rem;
+    }
+
+    &::after {
+      border-radius: 0.65rem;
+      height: calc(1.5rem - 4px);
+      width: calc(1.5rem - 4px);
+    }
+  }
+
+  .control-input:checked ~ .control-label::after {
+    transform: translateX(1rem);
+  }
 }

--- a/_sass/toggle.scss
+++ b/_sass/toggle.scss
@@ -35,4 +35,30 @@
   p {
     color: #fff !important;
   }
+
+  .adaptive-background {
+    background-color: #121212;
+  }
+
+  .adaptive-background-reverse {
+    background-color: #f5f5f9;
+  }
+  .adaptive-text {
+    color: #f5f5f9;
+  }
+  .adaptive-text-reverse {
+    color: #121212;
+  }
+
+  .adaptive-background-transparent {
+    background-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .adaptive-shadow{
+    filter: drop-shadow(0 0 0.75rem rgba(255,255,255,0.3));
+  }
+  .adaptive-theme-color {
+    background-color: #B9D1F2;
+  }
+
 }

--- a/_sass/toggle.scss
+++ b/_sass/toggle.scss
@@ -1,11 +1,11 @@
 [theme="dark"] {
-  background-color: #121212 !important;
+  background-color: #1e1e29 !important;
 
   .initiallogo {
-    background-color: #434343 !important;
+    background-color: #2a2b3c !important;
   }
   .finallogo {
-    background-color: #fff !important;
+    background-color: #1e1e29 !important;
   }
 }
 
@@ -13,31 +13,31 @@
   header,
   .profile,
   .banner {
-    background-color: #1a1919 !important;
+    background-color: #2a2b3c !important;
   }
 
   h1,
   h2,
   .control-label,
   .title {
-    color: #fff !important;
+    color: #cfcfd4 !important;
   }
 
   .card {
-    background-color: #434343 !important;
+    background-color: #2a2b3c !important;
   }
 
   .location {
-    color: #fff !important;
+    color: #9396a5 !important;
   }
 
   .dates,
   p {
-    color: #fff !important;
+    color: #9396a5 !important;
   }
 
   .adaptive-background {
-    background-color: #121212;
+    background-color: #1e1e29;
   }
 
   .adaptive-background-reverse {
@@ -47,18 +47,17 @@
     color: #f5f5f9;
   }
   .adaptive-text-reverse {
-    color: #121212;
+    color: #1e1e29;
   }
 
   .adaptive-background-transparent {
     background-color: rgba(255, 255, 255, 0.2);
   }
 
-  .adaptive-shadow{
-    filter: drop-shadow(0 0 0.75rem rgba(255,255,255,0.3));
+  .adaptive-shadow {
+    filter: drop-shadow(0 0 0.75rem rgba(255, 255, 255, 0.3));
   }
   .adaptive-theme-color {
-    background-color: #B9D1F2;
+    background-color: #b9d1f2;
   }
-
 }

--- a/_sass/toggle.scss
+++ b/_sass/toggle.scss
@@ -1,0 +1,38 @@
+[theme="dark"] {
+  background-color: #121212 !important;
+
+  .initiallogo {
+    background-color: #434343 !important;
+  }
+  .finallogo {
+    background-color: #fff !important;
+  }
+}
+
+[theme="dark"] {
+  header,
+  .profile,
+  .banner {
+    background-color: #1a1919 !important;
+  }
+
+  h1,
+  h2,
+  .control-label,
+  .title {
+    color: #fff !important;
+  }
+
+  .card {
+    background-color: #434343 !important;
+  }
+
+  .location {
+    color: #fff !important;
+  }
+
+  .dates,
+  p {
+    color: #fff !important;
+  }
+}

--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -11,6 +11,11 @@ const modeMapping = {
   1: "dark",
   2: "light"
 }
+const iconMapping = {
+  "auto": "bxs-brightness-half",
+  "dark": "bxs-moon",
+  "light": "bxs-sun",
+}
 
 window.addEventListener("load", function () {
   initTheme();
@@ -23,6 +28,12 @@ function initTheme() {
     currentMode = (currentMode + 1) % 3
     updateTheme(modeMapping[currentMode])
   })
+}
+
+function capitalise(text) {
+  if (text) {
+    return text[0].toUpperCase() + text.slice(1)
+  }
 }
 
 function updateTheme(modePreference, isInit = false) {
@@ -50,7 +61,15 @@ function updateTheme(modePreference, isInit = false) {
   }
 
   // Change the button text
-  darkModeStatusIndicator.innerText = modePreference
+  darkModeStatusIndicator.innerText = capitalise(modePreference)
+
+  // Sort out the right class for darkModeStatusIcon
+  const classes = ['bxs-moon', "bxs-sun", "bxs-brightness-half"]
+  classes.forEach(className => {
+    darkModeStatusIcon.classList.remove(className)
+  })
+  darkModeStatusIcon.classList.add(iconMapping[modePreference])
+
 
   beforeModeChange({ isDark, modePreference }).then(() => {
     isDark ? applyDarkMode() : applyLightMode()

--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -1,23 +1,85 @@
-var mode = document.getElementById("dark-theme-toggle");
+const darkModeButton = document.getElementById("dark-theme-toggle");
+const darkModeStatusIcon = document.getElementById("dark-mode-status-icon");
+const darkModeStatusIndicator = document.getElementById("dark-mode-status-indicator");
+// Mapping:
+// 0 - auto
+// 1 - dark
+// 2 - light
+var currentMode = 0;
+const modeMapping = {
+  0: "auto",
+  1: "dark",
+  2: "light"
+}
+
 window.addEventListener("load", function () {
   initTheme();
-
-  if (mode !== null) {
-    mode.addEventListener("change", function () {
-      resetTheme();
-    });
-  }
 });
 
 function initTheme() {
-  var darkThemeSelected =
-    localStorage.getItem("mode") !== null &&
-    localStorage.getItem("mode") === "dark";
+  const modePreference = localStorage.getItem("mode") ?? "auto"
+  updateTheme(modePreference, true)
+  darkModeButton.addEventListener("click", () => {
+    currentMode = (currentMode + 1) % 3
+    updateTheme(modeMapping[currentMode])
+  })
+}
 
-  if (mode !== null) mode.checked = darkThemeSelected;
-  darkThemeSelected
-    ? document.body.setAttribute("theme", "dark")
-    : document.body.removeAttribute("theme");
+function updateTheme(modePreference, isInit = false) {
+  var isDark = false
+  // Store the updated theme.
+  // This should be done before switch - ref: default case
+  localStorage.setItem("mode", modePreference)
+  switch (modePreference) {
+    case "auto":
+      isDark = window.matchMedia && window.matchMedia(' (prefers-color-scheme: dark)').matches
+      currentMode = 0
+      break
+    case "dark":
+      isDark = true
+      currentMode = 1
+      break
+    case "light":
+      isDark = false
+      currentMode = 2
+      break;
+    default:
+      // Invalid state, clear mode preference and reset to auto
+      localStorage.setItem("mode", null)
+      isDark = false
+  }
+
+  // Change the button text
+  darkModeStatusIndicator.innerText = modePreference
+
+  beforeModeChange({ isDark, modePreference }).then(() => {
+    isDark ? applyDarkMode() : applyLightMode()
+    // Remove the hidden tag - the hidden tag was added 
+    // to avoid flashing when switching pages in dark mode.
+    if (isInit) {
+      document.body.classList.remove("hidden")
+    }
+  }).then(() => {
+    afterModeChange({ isDark, modePreference })
+  })
+}
+
+async function beforeModeChange({ isDark, modePreference }) {
+  // [TODO] Set up the animation
+  return
+}
+
+async function afterModeChange({ isDark, modePreference }) {
+  // [TODO] Clean up the animation
+  return
+}
+
+function applyDarkMode() {
+  document.body.setAttribute("theme", "dark")
+}
+
+function applyLightMode() {
+  document.body.removeAttribute("theme");
 }
 
 function resetTheme() {

--- a/assets/js/toggle.js
+++ b/assets/js/toggle.js
@@ -1,0 +1,31 @@
+var mode = document.getElementById("dark-theme-toggle");
+window.addEventListener("load", function () {
+  initTheme();
+
+  if (mode !== null) {
+    mode.addEventListener("change", function () {
+      resetTheme();
+    });
+  }
+});
+
+function initTheme() {
+  var darkThemeSelected =
+    localStorage.getItem("mode") !== null &&
+    localStorage.getItem("mode") === "dark";
+
+  if (mode !== null) mode.checked = darkThemeSelected;
+  darkThemeSelected
+    ? document.body.setAttribute("theme", "dark")
+    : document.body.removeAttribute("theme");
+}
+
+function resetTheme() {
+  if (mode.checked) {
+    document.body.setAttribute("theme", "dark");
+    localStorage.setItem("mode", "dark");
+  } else {
+    document.body.removeAttribute("theme");
+    localStorage.removeItem("mode");
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,17 +1,19 @@
 ---
 ---
+
 <!DOCTYPE html>
 <html lang="en">
-{% include header.html %}
+  {% include header.html %}
 
-<body>
-    {% include navbar.html %}
+  <body>
+    {% include navbar.html %} {% include profile.html %} {% include
+    description.html %} {% include projects.html %} {% include toggle.html %}
 
-    {% include profile.html %}
-    
-    {% include description.html %}
-    
-    {% include projects.html %}
-</body>
-
+    <script>
+      const theme = localStorage.getItem("mode");
+      if (theme !== null) {
+        document.body.setAttribute("theme", "dark");
+      }
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,17 +3,12 @@
 
 <!DOCTYPE html>
 <html lang="en">
-  {% include header.html %}
+{% include header.html %}
 
-  <body>
-    {% include navbar.html %} {% include profile.html %} {% include
-    description.html %} {% include projects.html %} {% include toggle.html %}
+<body class="hidden">
+  {% include navbar.html %} {% include profile.html %} {% include
+  description.html %} {% include projects.html %} {% include toggle.html %}
 
-    <script>
-      const theme = localStorage.getItem("mode");
-      if (theme !== null) {
-        document.body.setAttribute("theme", "dark");
-      }
-    </script>
-  </body>
+</body>
+
 </html>


### PR DESCRIPTION
@yyjlincoln  and I have worked together on this PR. In this, we have added a toggle button that gives 3 options light mode, dark mode, and auto which displays according to the system preference. 

A glimpse of our work: [Demo](https://youtu.be/1xv1J13I970) Credit goes to @yyjlincoln for this! 

Features:
- The support of auto|light|dark
- Smooth transition between states
- No eye-blinding flash when switching pages
- When set to auto, it can listen to your phone's dark mode events and adjust its color scheme automatically
- Written in vanilla javascript, no additional libraries are used
- Flexible/modular design with functions such as `beforeModeChange` and `afterModeChange`, meaning that you can easily add more functionality to it.

- [X] My Pod Leader knows I'm working on this Pull Request
- [X] I've explained what the Pull Request is adding.
- [X] I've explained why this is important.


This pull request closes #15 