### PR TITLE
fix: Background image looks better when its size is cover

### DIFF
--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,5 +1,6 @@
 .profile {
     background: linear-gradient(to bottom, rgba(0, 0, 0, 0.05), black), no-repeat center/100% url('/assets/img/background.jpg'), #946c50;
+    background-size: cover;
     text-align: center;
     height: 320px;
     margin-bottom: 50px;


### PR DESCRIPTION
Quick fix of #27 - added one line to set the background size to cover.