### PR TITLE
feat: Experimental: Capture the browser's back/forward events and transit between pages

### DIFF
--- a/assets/js/page-transition.js
+++ b/assets/js/page-transition.js
@@ -16,7 +16,6 @@ async function beforePageTransition() {
             ease: "expo.out",
         }
     )
-
 }
 
 async function afterPageTransition() {
@@ -37,23 +36,50 @@ async function afterPageTransition() {
         }
     )
 
-    document.body.classList.remove("cursor-wait");
-    animationLayer.classList.add("animation-hidden");
+    if (animationLock === "after-new-page") {
+        // If it's not "after-new-page" then this means that the user initiated a page transition to another page before this transition is completed.
+        // Subsequent actions are handled by the other function.
+        document.body.classList.remove("cursor-wait");
+        animationLayer.classList.add("animation-hidden");
+    }
 }
 
-function pageTransition(href) {
+function pageTransition(href, { pushState = true } = {}) {
     latestHref = href
-    if (animationLock) {
+    if (animationLock === "before-new-page") {
         return
+    } else if (animationLock === "after-new-page") {
+        // This resets everything to their original location
+        timeline.pause()
+        timeline.seek(0)
+        // Then, reset the timeline as well.
+        timeline = gsap.timeline()
     }
-    animationLock = true
+    animationLock = "before-new-page"
     beforePageTransition().then(() => {
         // Add a flag so the next page can animate in
-        timeline.invalidate().clear()
-        localStorage.setItem("transition-enabled", "true");
-        localStorage.setItem("transition-from", window.location.href);
+        const isExternal = (latestHref.startsWith(location.origin) === false) && (latestHref.startsWith("/") === false)
+        if (!isExternal) {
+            localStorage.setItem("transition-enabled", "true");
+            localStorage.setItem("transition-from", window.location.href);
+            if (pushState) {
+                history.pushState(null, null, href);
+            }
+            setTimeout(() => {
+                // Called in case something gets stuck/safari (which caches the previous page)
+                animationLayer.classList.add("animation-hidden");
+                document.body.classList.remove("cursor-wait");
+                animationLock = null
+            }, 1000);
+
+            // Using push state then reload to allow us to capture back/forward button presses,
+            // as popState is only triggered if the state is pushed by pushState (not by the location.href).
+
+            // We could have used unload event but we can't distingush page close from back/forward.
+            location.reload();
+        }
         // Push to history
-        location.href = latestHref;
+        // location.href = latestHref;
     })
 }
 
@@ -62,9 +88,9 @@ function install() {
     if (localStorage.getItem("transition-enabled") === "true") {
         localStorage.setItem("transition-enabled", "");
         localStorage.setItem("transition-from", "");
-        animationLock = true
+        animationLock = "after-new-page"
         afterPageTransition(localStorage.getItem("transition-from")).then(() => {
-            animationLock = false
+            animationLock = null
         })
     }
     // Add a handler to all links
@@ -89,7 +115,8 @@ function install() {
         });
     }
     window.addEventListener("popstate", () => {
-        pageTransition(document.location.href)
+        // This is triggered when the user pressess the back/forward button. As the URL has already been changed by the browser, we need to manually push state.
+        pageTransition(document.location.href, { pushState: false });
     })
 }
 

--- a/assets/js/page-transition.js
+++ b/assets/js/page-transition.js
@@ -6,6 +6,7 @@ let animationLock = false;
 let timeline = gsap.timeline()
 
 async function beforePageTransition() {
+    gsap.to(window, { duration: 0.5, scrollTo: 0, ease: "expo.out" });
     animationLayer.classList.remove("animation-hidden");
     document.body.classList.add("cursor-wait");
     await timeline.from("#animation-layer",


### PR DESCRIPTION
In the previous version of `page-transition`, I was unable to capture the back/forward event and I didn't add a transition between pages when the user presses Back/Forward. I addressed this issue by using a combination of `history.pushState`, `history.popState` and `location.reload()` & replaced `location.href` with `history.pushState(); location.reload()`

